### PR TITLE
Fixed setup.py to include submodules and miscellaneous directories

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+recursive-include publications/templates *
+recursive-include publications/fixtures *

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from publications import __version__
 
 
@@ -12,10 +12,11 @@ setup(
     author_email='lucas@theis.io',
     description='A Django app for managing publications.',
     url='https://github.com/lucastheis/django-publications',
-    packages=['publications'],
-    install_requires=['Python>=2.5.0', 'Django>=1.3.0'],
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=('Python>=2.5.0', 'Django>=1.3.0'),
     license='MIT',
-    classifiers=[
+    classifiers=(
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -23,5 +24,5 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-    ]
+    )
 )


### PR DESCRIPTION
Hi again,

I just realized my previous setup.py was incorrect: it wasn't installing the sub-modules and other data directories such as templates/ and fixtures/. I fixed this by changing setup.py appropriately and by add a MANIFEST.in file.

I have tested it here and it seems alright now.
