### PR TITLE
verify_exists not present in django 1.5

### DIFF
--- a/publications/models/publication.py
+++ b/publications/models/publication.py
@@ -62,9 +62,9 @@ class Publication(models.Model):
 	note = models.CharField(max_length=256, blank=True)
 	keywords = models.CharField(max_length=256, blank=True,
 		help_text='List of keywords separated by commas.')
-	url = models.URLField(blank=True, verify_exists=False, verbose_name='URL',
+	url = models.URLField(blank=True, verbose_name='URL',
 		help_text='Link to PDF or journal page.')
-	code = models.URLField(blank=True, verify_exists=False,
+	code = models.URLField(blank=True,
 		help_text='Link to page with code.')
 	pdf = models.FileField(upload_to='publications/', verbose_name='PDF', blank=True, null=True)
 	doi = models.CharField(max_length=128, verbose_name='DOI', blank=True)


### PR DESCRIPTION
URLField options 'verify_exists' doesn't exist anymore for django 1.5.
Remove it from publication model or you get this:

$ python manage.py syncdb
TypeError: **init**() got an unexpected keyword argument 'verify_exists'
