### PR TITLE
Avoid unneeded bool(qs) evaluation in v0.7-dev

### DIFF
--- a/publications/models/orderedmodel.py
+++ b/publications/models/orderedmodel.py
@@ -54,7 +54,8 @@ class OrderedModel(models.Model):
         )
 
     def get_ordering_queryset(self, qs=None):
-        qs = qs or self.__class__._default_manager.all()
+        if qs is None:
+            qs = self.__class__._default_manager.all()
         order_with_respect_to = self.order_with_respect_to
         if order_with_respect_to:
             value = self._get_order_with_respect_to()


### PR DESCRIPTION
The `qs or ...` check will cause the queryset to be evaluated.
This small change avoids making unneeded queries.

p.s. Thanks for improving this project, glad to see there is new activity!
Will you release a 0.7 soon? That would help upgrading my project without needing to pin GitHub releases :-)