### PR TITLE
Redirect to change page after single BibTex upload

### DIFF
--- a/publications/admin_views/import_bibtex.py
+++ b/publications/admin_views/import_bibtex.py
@@ -156,7 +156,10 @@ def import_bibtex(request):
 			messages.info(request, msg)
 
 			# redirect to publication listing
-			return HttpResponseRedirect('../')
+			if len(publications) == 1:
+				return HttpResponseRedirect('../%s/change/' % publications[0].id)
+			else:
+				return HttpResponseRedirect('../')
 	else:
 		return render(
 			request,


### PR DESCRIPTION
Administrator taken directly to change page after upload of single BibTex entry, can make modifications easily.  Prevents having to search for the publication in the master admin list.