### PR TITLE
Updates CI to use supported versions of Django, Python and fixes admin on Django 3 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 dist: xenial
 language: python
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 env:
-    - DJANGO_VERSION=2.1.8
-    - DJANGO_VERSION=2.2.1
+    - DJANGO_VERSION=2.2.16
+    - DJANGO_VERSION=3.0.10
+    - DJANGO_VERSION=3.1.1
 branches:
     except:
         - media

--- a/publications/templates/admin/publications/import_bibtex.html
+++ b/publications/templates/admin/publications/import_bibtex.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify %}
+{% load i18n static admin_modify %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />{% endblock %}
 


### PR DESCRIPTION
Python 3.5 and Django 2.1 are now EOL, updates django versions according to https://www.djangoproject.com/download/, adds Python 3.8, and fixes the admin pages for Django 3.0+.

Closes #49 
