### PR TITLE
Add eprint fields

### DIFF
--- a/publications/admin/publicationadmin.py
+++ b/publications/admin/publicationadmin.py
@@ -36,7 +36,7 @@ class PublicationAdmin(admin.ModelAdmin):
 		(None, {'fields':
 			('citekey', 'keywords', 'url', 'code', 'pdf', 'doi', 'isbn', 'note', 'external')}),
 		(None, {'fields':
-			('abstract',)}),
+			('eprint', 'archiveprefix', 'primaryclass', 'abstract',)}),
 		(None, {'fields':
 			('image', 'thumbnail')}),
 		(None, {'fields':

--- a/publications/admin_views/import_bibtex.py
+++ b/publications/admin_views/import_bibtex.py
@@ -71,7 +71,10 @@ def import_bibtex(request):
 						'pages',
 						'note',
 						'abstract',
-						'month']
+						'month',
+						'eprint',
+						'primaryclass',
+						'archiveprefix']
 
 					for key in keys:
 						if not key in entry:
@@ -90,7 +93,15 @@ def import_bibtex(request):
 
 					# remove whitespace characters (likely due to line breaks)
 					entry['url'] = re.sub(r'\s', '', entry['url'])
+					entry['eprint'] = re.sub(r'\s', '', entry['eprint'])
 
+					# eprintclass and eprinttype are aliases for primaryclass and archiveprefix
+					if 'eprintclass' in entry:
+						entry['primaryclass'] = entry['eprintclass']
+					if 'eprinttype' in entry:
+						entry['archiveprefix'] = entry['eprinttype']
+
+					#
 					# determine type
 					type_id = None
 
@@ -122,6 +133,9 @@ def import_bibtex(request):
 						url=entry['url'],
 						doi=entry['doi'],
 						isbn=entry['isbn'],
+						eprint=entry['eprint'],
+						primaryclass=entry['primaryclass'],
+						archiveprefix=entry['archiveprefix'],
 						external=False,
 						abstract=entry['abstract'],
 						keywords=entry['keywords']))

--- a/publications/migrations/0003_add_eprint.py
+++ b/publications/migrations/0003_add_eprint.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.core import management
+
+class Migration(migrations.Migration):
+	dependencies = [
+		('publications', '0002_initial_data'),
+	]
+
+	operations = [
+        migrations.AddField(
+            model_name='publication',
+            name='eprint',
+            field=models.CharField(max_length=256, verbose_name='eprint', blank=True,
+				help_text='Link to electronic (preprint) or eprint identifier'),
+        ),
+        migrations.AddField(
+            model_name='publication',
+            name='primaryclass',
+            field=models.CharField(max_length=128, verbose_name='eprint class',
+				blank=True, help_text='Preprint classification'),
+        ),
+        migrations.AddField(
+            model_name='publication',
+            name='archiveprefix',
+            field=models.CharField(max_length=128, verbose_name='eprint type',
+				blank=True, help_text='Name of preprint archive'),
+        ),
+	]

--- a/publications/models/publication.py
+++ b/publications/models/publication.py
@@ -90,6 +90,12 @@ class Publication(models.Model):
 	isbn = models.CharField(max_length=32, verbose_name="ISBN", blank=True,
 		help_text='Only for a book.') # A-B-C-D
 	lists = models.ManyToManyField(List, blank=True)
+	eprint = models.CharField(max_length=256, verbose_name='eprint', blank=True,
+		help_text='Link to electronic (preprint) or eprint identifier')
+	primaryclass = models.CharField(max_length=128, verbose_name='eprint class',
+		blank=True, help_text='Preprint classification')
+	archiveprefix = models.CharField(max_length=128, verbose_name='eprint type',
+		blank=True, help_text='Name of preprint archive')
 
 	def __init__(self, *args, **kwargs):
 		models.Model.__init__(self, *args, **kwargs)

--- a/publications/models/publication.py
+++ b/publications/models/publication.py
@@ -293,6 +293,17 @@ class Publication(models.Model):
 	def last_page(self):
 		return self.pages.split('-')[-1]
 
+	def eprint_link(self):
+		if self.eprint.startswith('http'):
+			return urlquote_plus(self.eprint)
+		elif self.archiveprefix == 'arXiv':
+			return ('https://arxiv.org/abs/' +
+				urlquote_plus(self.eprint))
+		elif self.archiveprefix == 'pmcid':
+			return ('http://www.ncbi.nlm.nih.gov/pmc/articles/' +
+				urlquote_plus(self.eprint))
+		else:
+			return
 
 	def z3988(self):
 		contextObj = ['ctx_ver=Z39.88-2004']

--- a/publications/templates/publications/publication.bib
+++ b/publications/templates/publications/publication.bib
@@ -14,5 +14,8 @@
   doi = "{{ publication.doi }}"{% endif %}{% if publication.url %},
   url = "{{ publication.url }}"{% endif %}{% if publication.note %},
   note = "{{ publication.note }}"{% endif %}{% if publication.isbn %},
-  isbn = "{{ publication.isbn }}"{% endif %}
+  isbn = "{{ publication.isbn }}"{% endif %}{% if publication.eprint %},
+  eprint = "{{ publication.eprint }}"{% endif %}{% if publication.primaryclass %},
+  primaryclass = "{{ publication.primaryclass }}"{% endif %}{% if publication.archiveprefix %},
+  archiveprefix = "{{ publication.archiveprefix }}"{% endif %}
 }

--- a/publications/templates/publications/publication.html
+++ b/publications/templates/publications/publication.html
@@ -36,6 +36,7 @@
 {% if publication.code %}<a class="link" href="{{ publication.code }}">Code</a>,{% endif %}
 {% if publication.url %}<a class="link" rel="external" href="{{ publication.url }}">URL</a>,{% endif %}
 {% if publication.doi %}<a class="link" rel="external" href="http://dx.doi.org/{{ publication.doi }}">DOI</a>,{% endif %}
+{% if publication.eprint_link %}<a class="link" rel="external" href="{{ publication.eprint_link }}">Eprint</a>,{% endif %}
 {% if not publication.journal and publication.isbn %}<a class="link" rel="external" href="http://isbndb.com/search/all?query={{ publication.isbn }}">ISBN</a>,{% endif %}
 {% if publication.pdf %}<a class="link" href="{{ MEDIA_URL }}{{ publication.pdf }}">PDF</a>,{% endif %}
 {% for file in publication.files %}

--- a/publications/tests/tests.py
+++ b/publications/tests/tests.py
@@ -85,6 +85,8 @@ class Tests(TestCase):
 			title=u'Slowness and sparseness have diverging effects on complex cell learning',
 			year=2014,
 			journal=u'PLoS Computational Biology',
+			eprint=u'PMC3945087',
+			archiveprefix=u'pmcid',
 			external=0)
 		publication.clean()
 		publication.save()
@@ -259,7 +261,11 @@ TEST_BIBLIOGRAPHY = r"""
   number={3},
   pages={433--452},
   year={2000},
-  publisher={Oxford University Press}
+  publisher={Oxford University Press},
+  eprint={9905086},
+  eprinttype={arXiv},
+  eprintclass={astro-ph}
+
 }
 
 @misc{test:2009,
@@ -279,7 +285,10 @@ TEST_BIBLIOGRAPHY = r"""
  url       = {http://arxiv.org/abs/1409.7686},
  timestamp = {Mon, 27 Oct 2014 13:50:21 +0100},
  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/corr/KummererWB14},
- bibsource = {dblp computer science bibliography, http://dblp.org}
+ bibsource = {dblp computer science bibliography, http://dblp.org},
+ eprint    = {1409.7686},
+ primaryclass = {cs.CV},
+ archiveprefix = {arXiv},
 }
 @incollection{dougan2014objective,
   title={Objective Functions},


### PR DESCRIPTION
This adds fields for eprints according [arXiv](https://arxiv.org/help/hypertex/bibstyles)

Currently supports:
- archiveprefix:
  - arXiv
  - pmcid
- Bibtex output
- Link in HTML view
